### PR TITLE
Develop

### DIFF
--- a/src/components/TrelloCard.js
+++ b/src/components/TrelloCard.js
@@ -7,6 +7,8 @@ import Icon from "@material-ui/core/Icon";
 import TrelloForm from "./TrelloForm";
 import TrelloButton from "./TrelloButton";
 import { Draggable } from "react-beautiful-dnd";
+import { useDispatch } from "react-redux";
+import { editCard } from "../modules/cardReducer";
 
 const CardContainer = styled.div`
   margin: 0 0 8px 0;
@@ -47,6 +49,7 @@ const DeleteButton = styled(Icon)`
 function TrelloCard({ text, id, index, listID }) {
   console.log(text);
   console.log(id);
+  const dispatch = useDispatch();
   const [edit, setEdit] = useState(false);
   const [cardText, setText] = useState(text);
   console.log(cardText);
@@ -58,6 +61,7 @@ function TrelloCard({ text, id, index, listID }) {
   };
   const saveCard = e => {
     e.preventDefault();
+    dispatch(editCard(id, listID, cardText));
     setEdit(false);
   };
   const renderEditForm = () => {
@@ -81,6 +85,9 @@ function TrelloCard({ text, id, index, listID }) {
             ref={porvided.innerRef}
           >
             <Card>
+              <EditButton onMouseDown={() => setEdit(true)} fontSize="small">
+                edit
+              </EditButton>
               <CardContent>
                 <Typography>{text}</Typography>
               </CardContent>

--- a/src/components/TrelloCard.js
+++ b/src/components/TrelloCard.js
@@ -25,6 +25,7 @@ const EditButton = styled(Icon)`
   opacity: 0.5;
   ${CardContainer}:hover & {
     display: block;
+    color: #01df01;
     cursor: pointer;
   }
   &:hover {
@@ -40,6 +41,7 @@ const DeleteButton = styled(Icon)`
   opacity: 0.5;
   ${CardContainer}:hover & {
     display: block;
+    color: #df013a;
     cursor: pointer;
   }
   &:hover {
@@ -88,9 +90,12 @@ function TrelloCard({ text, id, index, listID }) {
             ref={porvided.innerRef}
           >
             <Card>
-              <EditButton onMouseDown={() => setEdit(true)} fontSize="small">
-                edit
-              </EditButton>
+              {cardText && (
+                <EditButton onMouseDown={() => setEdit(true)} fontSize="small">
+                  edit
+                </EditButton>
+              )}
+
               <DeleteButton fontSize="small" onMouseDown={handleDeleteCard}>
                 delete
               </DeleteButton>

--- a/src/components/TrelloCard.js
+++ b/src/components/TrelloCard.js
@@ -8,7 +8,7 @@ import TrelloForm from "./TrelloForm";
 import TrelloButton from "./TrelloButton";
 import { Draggable } from "react-beautiful-dnd";
 import { useDispatch } from "react-redux";
-import { editCard } from "../modules/cardReducer";
+import { editCard, deleteCard } from "../modules/cardReducer";
 
 const CardContainer = styled.div`
   margin: 0 0 8px 0;
@@ -47,7 +47,7 @@ const DeleteButton = styled(Icon)`
   }
 `;
 function TrelloCard({ text, id, index, listID }) {
-  console.log(text);
+  console.log(listID);
   console.log(id);
   const dispatch = useDispatch();
   const [edit, setEdit] = useState(false);
@@ -63,6 +63,9 @@ function TrelloCard({ text, id, index, listID }) {
     e.preventDefault();
     dispatch(editCard(id, listID, cardText));
     setEdit(false);
+  };
+  const handleDeleteCard = e => {
+    dispatch(deleteCard(id, listID));
   };
   const renderEditForm = () => {
     return (
@@ -88,6 +91,9 @@ function TrelloCard({ text, id, index, listID }) {
               <EditButton onMouseDown={() => setEdit(true)} fontSize="small">
                 edit
               </EditButton>
+              <DeleteButton fontSize="small" onMouseDown={handleDeleteCard}>
+                delete
+              </DeleteButton>
               <CardContent>
                 <Typography>{text}</Typography>
               </CardContent>

--- a/src/components/TrelloList.js
+++ b/src/components/TrelloList.js
@@ -61,7 +61,7 @@ function TrelloList({ title, cards, listID, list, index }) {
                         key={card.id}
                         id={card.id}
                         index={index}
-                        list={listID}
+                        listID={listID}
                       />
                     );
                   })}

--- a/src/components/TrelloList.js
+++ b/src/components/TrelloList.js
@@ -4,6 +4,7 @@ import TrelloCard from "../components/TrelloCard";
 import { useSelector } from "react-redux";
 import TrelloAdd from "./TrelloAdd";
 import { Draggable, Droppable } from "react-beautiful-dnd";
+import { useState } from "react";
 
 const ListContainer = styled.div`
   background-color: #dfe3e6;

--- a/src/modules/cardReducer.js
+++ b/src/modules/cardReducer.js
@@ -1,7 +1,7 @@
 import uuid from "uuid/v4";
 const ADD_CARD = "ADD_CARD";
 const EDIT_CARD = "EDIT_CARD";
-
+const DELETE_CARD = "DELETE_CARD";
 export const addCard = (listID, text) => {
   const id = uuid();
   return {
@@ -15,7 +15,12 @@ export const editCard = (id, listID, cardText) => {
     payload: { id, listID, cardText }
   };
 };
-
+export const deleteCard = (id, listID) => {
+  return {
+    type: DELETE_CARD,
+    payload: { id, listID }
+  };
+};
 const initialState = {
   "0카드": {
     text: "전에할일",
@@ -41,6 +46,12 @@ export default function cardReducer(state = initialState, action) {
       const card = state[id];
       card.text = cardText;
       return { ...state, [`${id}카드`]: card };
+    }
+    case DELETE_CARD: {
+      const { id } = action.payload;
+      const deleteState = state;
+      delete deleteState[id];
+      return deleteState;
     }
     default:
       return state;

--- a/src/modules/cardReducer.js
+++ b/src/modules/cardReducer.js
@@ -9,11 +9,17 @@ export const addCard = (listID, text) => {
     payload: { listID, text, id }
   };
 };
+export const editCard = (id, listID, cardText) => {
+  return {
+    type: EDIT_CARD,
+    payload: { id, listID, cardText }
+  };
+};
 
 const initialState = {
   "0카드": {
     text: "전에할일",
-    id: `0카드`,
+    id: "0카드",
     list: "0리스트"
   }
 };
@@ -29,6 +35,12 @@ export default function cardReducer(state = initialState, action) {
         list: listID
       };
       return { ...state, [`${id}카드`]: newCard };
+    }
+    case EDIT_CARD: {
+      const { id, cardText } = action.payload;
+      const card = state[id];
+      card.text = cardText;
+      return { ...state, [`${id}카드`]: card };
     }
     default:
       return state;

--- a/src/modules/listReducer.js
+++ b/src/modules/listReducer.js
@@ -2,12 +2,18 @@ import uuid from "uuid/v4";
 const ADD_CARD = "ADD_CARD";
 const ADD_LIST = "ADD_LIST";
 const DRAG_HAPPENED = "DRAG_HAPPENED";
+const DELETE_CARD = "DELETE_CARD";
 
 export const addList = title => {
   const id = uuid();
   return { type: ADD_LIST, payload: { title, id } };
 };
-
+export const deleteCard = (id, listID) => {
+  return {
+    type: DELETE_CARD,
+    payload: { id, listID }
+  };
+};
 const initialState = {
   "0리스트": {
     id: "0리스트",
@@ -82,7 +88,14 @@ export default function listReducer(state = initialState, action) {
         };
       }
       return state;
+    case DELETE_CARD: {
+      const { listID, id } = action.payload;
 
+      const list = state[listID];
+
+      const newCards = list.cards.filter(cardID => cardID !== id);
+      return { ...state, [listID]: { ...list, cards: newCards } };
+    }
     default:
       return state;
   }

--- a/src/modules/listReducer.js
+++ b/src/modules/listReducer.js
@@ -82,6 +82,7 @@ export default function listReducer(state = initialState, action) {
         };
       }
       return state;
+
     default:
       return state;
   }


### PR DESCRIPTION
수정, 삭제 기능 추가하였다. 

수정.
수정은 카드 리듀서만 수정하면됨. 왜냐면 카드리듀서의 이니셜 값이 객체인데 그 객체안에 card객체들이있고, 특정 (선택해서 수정한 카드)카드의 아이디를 써주고  text가 포함된 객체의 수정된 값을 덮어써주기만하면 같은 이름의 카드에 카드내용이 덮어 써진다. 
삭제.
리스트의 카드배열안의 이름부여한것과 카드리듀서에서 객체에 이름부여 한것을 같게 해서 덮어쓰는 것이니까  삭제 할때는 배열의 값이 바뀌므로  리스트 리듀서와 카드 리듀서 둘다 바꿔줘야한다. 카드 리듀서에는 단지 객체안에 값을 빼기만 하면되고 리스트 리듀서에는  list안의 cards가 배열이니까 배열안에는 [" 이름" , "이름2"]이런식으로 만 들어있으니까 이 배열의 원소가  디스패치로 넘어온 id(결국.. card.id)와 같으니까 이것을 제외한 것만 새배열에 반환 하고  그 새배열 (cards 안에 들어갈 바뀐 내용들을 가진 배열 ) 을 리스트 리듀서의 이니셜값은 객체로 이루어져있으니까 spread연산으로 복사해서  덮어쓴다.  